### PR TITLE
Launch model containers with model images in python

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -2,11 +2,11 @@ name: Python CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, python-cli ]
     paths:
       - 'python_cli/**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, python-cli ]
     paths:
       - 'python_cli/**'
 

--- a/python_cli/README.md
+++ b/python_cli/README.md
@@ -3,9 +3,17 @@
 Command line interface for managing Liquid Labs on-prem stack.
 
 ## Installation
-
 ```bash
 pip install liquidai-cli
+```
+
+A `docker-compose.yaml` file is also shipped together with the package. Any changes to this file may cause some unexpected behaviors.
+
+### Run with `uv`
+`uv` allows to run this tool without installing the package into the system.
+
+```bash
+uv run --directory [PATH_TO_THIS_DIRECTORY] liquidai [command] [args]
 ```
 
 ## Configuration
@@ -53,6 +61,11 @@ liquidai stack purge --force
 ### Model Operations
 
 ```bash
+# Run a model in docker container
+liquidai model run-model-image \
+  --name lfm-3b-e \
+  --image "liquidai/lfm-3b-e:0.0.6"
+
 # Run a HuggingFace model
 liquidai model run-hf \
   --name llama-7b \
@@ -113,51 +126,4 @@ liquidai config import --force
 ```
 
 ## Command Reference
-
-### Stack Commands
-
-- `launch [--upgrade-stack] [--upgrade-model]`: Launch the stack
-  - `--upgrade-stack`: Upgrade stack version
-  - `--upgrade-model`: Upgrade model version
-- `shutdown`: Shutdown the stack
-- `test`: Test API endpoints
-- `purge [--force]`: Remove all components
-  - `--force`: Skip confirmation prompt
-
-### Model Commands
-
-- `run-hf`: Run a HuggingFace model
-  - `--name`: Name for the model container
-  - `--path`: HuggingFace model path
-  - `--port`: Port to expose (default: 9000)
-  - `--gpu`: GPU index to use (default: "all")
-  - `--gpu-memory-utilization`: GPU memory fraction (default: 0.6)
-  - `--max-num-seqs`: Max parallel sequences (default: 600)
-  - `--max-model-len`: Max model length (default: 32768)
-  - `--hf-token`: HuggingFace token (or use HUGGING_FACE_TOKEN env var)
-
-- `run-checkpoint`: Run a local checkpoint
-  - `--path`: Path to checkpoint directory
-  - `--port`: Port to expose (default: 9000)
-  - `--gpu`: GPU index to use (default: "all")
-  - `--gpu-memory-utilization`: GPU memory fraction (default: 0.6)
-  - `--max-num-seqs`: Max parallel sequences (default: 600)
-
-- `list`: List running models
-- `stop [NAME]`: Stop a model (interactive if NAME not provided)
-
-### Database Commands
-
-- `connect`: Connect to database using pgcli
-
-### Infrastructure Commands
-
-- `tunnel create [--token TOKEN]`: Create Cloudflare tunnel
-  - `--token`: Cloudflare tunnel token
-
-### Configuration Commands
-
-- `config import [--env-file PATH] [--config-file PATH] [--force]`: Import .env configuration
-  - `--env-file`: Path to .env file (default: .env)
-  - `--config-file`: Path to YAML config file (default: liquid.yaml)
-  - `--force`: Force overwrite existing config
+Call `liquidai [command] --help` to get the detailed usage reference.

--- a/python_cli/docker-compose.yaml
+++ b/python_cli/docker-compose.yaml
@@ -1,0 +1,96 @@
+# Docker Compose file for on-prem-stack Python CLI.
+services:
+  liquid-labs-python-api:
+    image: liquidai/liquid-labs-python-api:${STACK_VERSION}
+    container_name: liquid-labs-python-api
+    depends_on:
+      liquid-labs-web:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8000/health" ]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+      start_interval: 5s
+    environment:
+      # When ENV=production, http requests will be redirected to https
+      - ENV=internal
+      - IS_DOCKER=true
+      - CONTAINER_PORT=9000
+      - VLLM_IMAGE_NAME=liquidai/liquid-labs-vllm:${STACK_VERSION}
+      - JWT_SECRET=${JWT_SECRET}
+      - API_SECRET=${API_SECRET}
+      - NVIDIA_VISIBLE_DEVICES=all
+      - POSTGRES_SCHEMA=labs
+      - DATABASE_URL=${DATABASE_URL}
+    ports:
+      - "8000:8000"
+    networks:
+      - liquid_labs_network
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    # This is equivalent to "runtime: nvidia", but does not require
+    # the nvidia-container-runtime to be added in docker config.
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [ gpu ]
+
+  liquid-labs-postgres:
+    image: postgres:15
+    container_name: liquid-labs-postgres
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_SCHEMA: ${POSTGRES_SCHEMA}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PORT}:5432"
+    networks:
+      - liquid_labs_network
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  liquid-labs-web:
+    image: liquidai/liquid-labs-web:${STACK_VERSION}
+    container_name: liquid-labs-web
+    depends_on:
+      liquid-labs-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:3000/api/health" ]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+      start_interval: 5s
+    environment:
+      - NEXT_PUBLIC_API_BASE_URL=http://liquid-labs-python-api:8000
+      - API_SECRET=${API_SECRET}
+      - AUTH_SECRET=${AUTH_SECRET}
+      - JWT_SECRET=${JWT_SECRET}
+      - NEXT_PUBLIC_DEPLOYMENT_MODE=on_prem
+      - DATABASE_URL=${DATABASE_URL}
+    networks:
+      - liquid_labs_network
+    ports:
+      - "3000:3000"
+
+networks:
+  liquid_labs_network:
+    name: liquid_labs_network
+    driver: bridge
+
+volumes:
+  postgres_data:
+    external: true

--- a/python_cli/liquidai_cli/commands/model.py
+++ b/python_cli/liquidai_cli/commands/model.py
@@ -10,14 +10,19 @@ from typing_extensions import Annotated
 app = typer.Typer(help="Manage ML models")
 docker_helper = DockerHelper()
 
+
 @app.command(name="run-model-image")
 def run_model_image(
     name: str = typer.Option(..., "--name", help="Name for the model"),
     model_image: str = typer.Option(..., "--image", help="Model image name"),
     port: Annotated[int, typer.Option("--port", help="Port to expose locally")] = 9000,
     gpu: Annotated[str, typer.Option("--gpu", help="Specific GPU index to use")] = "all",
-    gpu_memory_utilization: Annotated[float, typer.Option("--gpu-memory-utilization", help="Fraction of GPU memory to use")] = 0.6,
-    max_num_seqs: Annotated[int, typer.Option("--max-num-seqs", help="Maximum number of sequences to generate in parallel")] = 750,
+    gpu_memory_utilization: Annotated[
+        float, typer.Option("--gpu-memory-utilization", help="Fraction of GPU memory to use")
+    ] = 0.6,
+    max_num_seqs: Annotated[
+        int, typer.Option("--max-num-seqs", help="Maximum number of sequences to generate in parallel")
+    ] = 750,
     max_model_len: Annotated[int, typer.Option("--max-model-len", help="Maximum length of the model")] = 32768,
 ):
     """
@@ -33,7 +38,7 @@ def run_model_image(
         image=model_image,
         name=model_volume_loader_container_name,
         volumes={model_volume_name: {"bind": "/model", "mode": "rw"}},
-        network="liquid_labs_network"
+        network="liquid_labs_network",
     )
     result = model_volume_loader_container.wait()
     if result["StatusCode"] != 0:
@@ -44,10 +49,10 @@ def run_model_image(
     typer.echo(f"Launching model container: {name}")
     stack_version = docker_helper.get_env_var("STACK_VERSION")
     if gpu == "all":
-        device_requests=[{"Driver": "nvidia", "Count": -1, "Capabilities": [["gpu"]]}]
+        device_requests = [{"Driver": "nvidia", "Count": -1, "Capabilities": [["gpu"]]}]
     else:
         gpu_indices = gpu.split(",")
-        device_requests=[{"Driver": "nvidia", "DeviceIds": gpu_indices, "Capabilities": [["gpu"]]}]
+        device_requests = [{"Driver": "nvidia", "DeviceIds": gpu_indices, "Capabilities": [["gpu"]]}]
     docker_helper.run_container(
         image=f"liquidai/liquid-labs-vllm:{stack_version}",
         name=name,
@@ -79,7 +84,7 @@ def run_model_image(
             str(max_num_seqs),
             "--max-seq-len-to-capture",
             str(max_model_len),
-        ]
+        ],
     )
     typer.echo(f"Model '{name}' started successfully")
     typer.echo("Please wait 1-2 minutes for the model to load before making API calls")

--- a/python_cli/liquidai_cli/commands/model.py
+++ b/python_cli/liquidai_cli/commands/model.py
@@ -39,6 +39,7 @@ def run_model_image(
     if result["StatusCode"] != 0:
         typer.echo(f"Error loading model data: {result['StatusCode']}", err=True)
         raise typer.Exit(1)
+    model_volume_loader_container.remove()
 
     typer.echo(f"Launching model container: {name}")
     stack_version = docker_helper.get_env_var("STACK_VERSION")

--- a/python_cli/liquidai_cli/commands/model.py
+++ b/python_cli/liquidai_cli/commands/model.py
@@ -52,7 +52,8 @@ def run_model_image(
         device_requests = [{"Driver": "nvidia", "Count": -1, "Capabilities": [["gpu"]]}]
     else:
         gpu_indices = gpu.split(",")
-        device_requests = [{"Driver": "nvidia", "DeviceIds": gpu_indices, "Capabilities": [["gpu"]]}]
+        print(gpu_indices)
+        device_requests = [{"Driver": "nvidia", "DeviceIDs": gpu_indices, "Capabilities": [["gpu"]]}]
     docker_helper.run_container(
         image=f"liquidai/liquid-labs-vllm:{stack_version}",
         name=name,

--- a/python_cli/liquidai_cli/commands/model.py
+++ b/python_cli/liquidai_cli/commands/model.py
@@ -52,7 +52,6 @@ def run_model_image(
         device_requests = [{"Driver": "nvidia", "Count": -1, "Capabilities": [["gpu"]]}]
     else:
         gpu_indices = gpu.split(",")
-        print(gpu_indices)
         device_requests = [{"Driver": "nvidia", "DeviceIDs": gpu_indices, "Capabilities": [["gpu"]]}]
     docker_helper.run_container(
         image=f"liquidai/liquid-labs-vllm:{stack_version}",

--- a/python_cli/liquidai_cli/commands/stack.py
+++ b/python_cli/liquidai_cli/commands/stack.py
@@ -59,7 +59,7 @@ def launch(
     # Launch stack
     docker_helper.run_compose(Path("docker-compose.yaml"))
     # Run default model image
-    run_model_image(model_name, config["stack"]["model_image"])        
+    run_model_image(model_name, config["stack"]["model_image"])
 
     typer.echo("The on-prem stack is now running.")
 
@@ -137,7 +137,7 @@ def test():
     typer.echo("\nTesting model call...")
     for model_info in available_model_json["data"]:
         model_name = model_info["id"]
-        if model_info['status'] == "running":
+        if model_info["status"] == "running":
             typer.echo(f"Testing model: {model_name}")
             data = {
                 "model": model_name,

--- a/python_cli/liquidai_cli/utils/device.py
+++ b/python_cli/liquidai_cli/utils/device.py
@@ -1,0 +1,24 @@
+"""
+Utils on managing devices parameters.
+"""
+
+from docker.types import DeviceRequest
+from typing import List
+
+
+def get_device_requests_from_gpus(gpus: str) -> List[DeviceRequest]:
+    """
+    Get device requests for GPUs.
+    Args:
+        gpus (str): requested gpus in a comma-separated string, or "all".
+    Returns:
+        List[DeviceRequest]: List of device requests for Docker.
+    """
+    if not gpus:
+        return []
+
+    if gpus == "all":
+        return [{"Driver": "nvidia", "Count": -1, "Capabilities": [["gpu"]]}]
+    else:
+        gpu_indices = gpus.split(",")
+        return [{"Driver": "nvidia", "DeviceIDs": gpu_indices, "Capabilities": [["gpu"]]}]

--- a/python_cli/liquidai_cli/utils/docker.py
+++ b/python_cli/liquidai_cli/utils/docker.py
@@ -9,6 +9,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class DockerHelper:
     def __init__(self, env_file: Path = Path(".env")):
         self.client = docker.from_env()
@@ -68,9 +69,7 @@ class DockerHelper:
         image_base_name = ancestor.split(":")[0]
         images = self.client.images.list(name=image_base_name)
         for image in images:
-            containers = self.client.containers.list(
-                filters={"ancestor": image.id}
-            )
+            containers = self.client.containers.list(filters={"ancestor": image.id})
             matching_containers.update(containers)
         result = []
         for c in matching_containers:
@@ -92,7 +91,7 @@ class DockerHelper:
             container.remove()
         except NotFound:
             pass
-    
+
     def get_env_var(self, key: str) -> str:
         """Get an environment variable from the env_file."""
         if key in self.env_dict:

--- a/python_cli/liquidai_cli/utils/docker.py
+++ b/python_cli/liquidai_cli/utils/docker.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any
 import docker
 from docker.errors import NotFound
 from pathlib import Path
-import logging 
+import logging
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +13,7 @@ class DockerHelper:
     def __init__(self, env_file: Path = Path(".env")):
         self.client = docker.from_env()
         self.env_file = env_file
+        self.env_dict = {}
 
     def run_compose(self, compose_file: Path, action: str = "up") -> None:
         """Run docker-compose command."""
@@ -48,7 +49,7 @@ class DockerHelper:
         except NotFound:
             pass
 
-    def run_container(self, image: str, name: str, **kwargs) -> None:
+    def run_container(self, image: str, name: str, **kwargs) -> docker.models.containers.Container:
         """Run a Docker container."""
         try:
             container = self.client.containers.get(name)
@@ -56,7 +57,7 @@ class DockerHelper:
         except NotFound:
             pass
 
-        self.client.containers.run(image, name=name, detach=True, **kwargs)
+        return self.client.containers.run(image, name=name, detach=True, **kwargs)
 
     def list_containers(self, ancestor: str) -> List[Dict[str, Any]]:
         """List containers by ancestor image."""
@@ -91,9 +92,20 @@ class DockerHelper:
             container.remove()
         except NotFound:
             pass
+    
+    def get_env_var(self, key: str) -> str:
+        """Get an environment variable from the env_file."""
+        if key in self.env_dict:
+            return self.env_dict[key]
+        with open(self.env_file, "r") as f:
+            for line in f:
+                if line.startswith(key):
+                    return line.split("=")[1].strip()
+        return ""
 
     def set_and_export_env_var(self, key: str, value: str) -> None:
         """Set and export an environment variable into env_file."""
+        self.env_dict[key] = value
         with open(self.env_file, "r") as f:
             lines = f.readlines()
         # Check if the key already exists


### PR DESCRIPTION
# Summary
A new command `liquidai model run-model-image` is added to launch a model with our model images. Also refactor the stack launch/test/shutdown to work with the new mode launch approach. The new `docker-compose.yaml` file only describes the python-api, DB and web containers. All model containers will be managed and launched by the python `model` commands.

The end-to-end test flow are list here:
## Launch
```
(base) ubuntu@192-222-52-66:~/git/on-prem-stack/python_cli$ uv run liquidai stack launch 
Setting JWT_SECRET
Setting API_SECRET
Setting AUTH_SECRET
Setting STACK_VERSION
Setting MODEL_IMAGE
Setting MODEL_NAME
Setting POSTGRES_DB
Setting POSTGRES_USER
Setting POSTGRES_PASSWORD
Setting POSTGRES_PORT
Setting POSTGRES_SCHEMA
Setting DATABASE_URL
WARN[0000] a network with name liquid_labs_network exists but was not created for project "python_cli".
Set `external: true` to use an existing network 
[+] Running 3/3
 ✔ Container liquid-labs-postgres    Healthy                                                                                                                                                        12.0s 
 ✔ Container liquid-labs-web         Healthy                                                                                                                                                        12.0s 
 ✔ Container liquid-labs-python-api  Healthy                                                                                                                                                        17.0s 
Creating volume for model data: lfm-7b-e
Loading model data from image: liquidai/lfm-7b-e:0.0.1
Launching model container: lfm-7b-e
Model 'lfm-7b-e' started successfully
Please wait 1-2 minutes for the model to load before making API calls
The on-prem stack is now running.
```

## Stop a model 
```
(base) ubuntu@192-222-52-66:~/git/on-prem-stack/python_cli$ uv run liquidai model stop lfm-7b-e
Stopped and removed container: lfm-7b-e
```

## Launch a new model
```
(base) ubuntu@192-222-52-66:~/git/on-prem-stack/python_cli$ uv run liquidai model run-model-image --name lfm-3b-e --image "liquidai/lfm-3b-e:0.0.6"
Creating volume for model data: lfm-3b-e
Loading model data from image: liquidai/lfm-3b-e:0.0.6
Launching model container: lfm-3b-e
Model 'lfm-3b-e' started successfully
Please wait 1-2 minutes for the model to load before making API calls
```

## Test a model
```
(base) ubuntu@192-222-52-66:~/git/on-prem-stack/python_cli$ uv run liquidai stack test 
Testing API call to get available models...
{'data': [{'id': 'lfm-3b-e', 'status': 'running'}]}

Testing model call...
Testing model: lfm-3b-e
{'id': 'chatcmpl-59437b10fb3a4a99aa7d279632d3e1f2', 'choices': [{'finish_reason': 'stop', 'index': 0, 'message': {'content': 'Silver melts at approximately 961.78 degrees Celsius (1,763.10 degrees Fahrenheit). This is a key property of the metal, which is used in various applications due to its high melting point and thermal conductivity.', 'role': 'assistant', 'tool_calls': []}}], 'created': 1745346397, 'model': 'lfm-3b-e', 'object': 'chat.completion', 'usage': {'completion_tokens': 51, 'prompt_tokens': 40, 'total_tokens': 91}}
```

## Shutdown the stack
```
(base) ubuntu@192-222-52-66:~/git/on-prem-stack/python_cli$ uv run liquidai stack shutdown
Stopped and removed model container: lfm-3b-e
[+] Running 3/3
 ✔ Container liquid-labs-python-api  Removed                                                                                                                                                         0.4s 
 ✔ Container liquid-labs-web         Removed                                                                                                                                                        10.2s 
 ✔ Container liquid-labs-postgres    Removed                                                                                                                                                         0.2s 
Stack has been shut down.
```
