### PR TITLE
Python CLI incremental bug fixes

### DIFF
--- a/python_cli/liquidai_cli/utils/docker.py
+++ b/python_cli/liquidai_cli/utils/docker.py
@@ -19,14 +19,14 @@ class DockerHelper:
 
     def run_compose(self, compose_file: Path, action: str = "up") -> None:
         """Run docker-compose command."""
-        cmd = ["docker", "compose", "--env-file", str(self.env_file)]
+        cmd = ["docker", "compose", "--env-file", str(self.env_file), "-f", str(compose_file)]
 
         if action == "up":
             cmd.extend(["up", "-d", "--wait"])
         elif action == "down":
             cmd.extend(["down"])
 
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=True)
 
     def ensure_volume(self, name: str) -> None:
         """Ensure a Docker volume exists."""

--- a/python_cli/liquidai_cli/utils/docker.py
+++ b/python_cli/liquidai_cli/utils/docker.py
@@ -14,6 +14,7 @@ class DockerHelper:
     def __init__(self, env_file: Path = Path(".env")):
         self.client = docker.from_env()
         self.env_file = env_file
+        env_file.touch()
         self.env_dict = {}
 
     def run_compose(self, compose_file: Path, action: str = "up") -> None:

--- a/python_cli/pyproject.toml
+++ b/python_cli/pyproject.toml
@@ -14,10 +14,7 @@ authors = [
 ]
 dependencies = [
     "typer>=0.9.0",
-    "python-dotenv>=1.0.0",
     "docker>=6.1.0",
-    "rich>=10.11.0",
-    "pydantic>=2.0.0",
     "ruamel.yaml>=0.17.21"
 ]
 


### PR DESCRIPTION
1. `env_file` doesn't exist on the first run. Fixing this issue by touching the file when docker help is initialized.
2. Terminate the stack operations when `docker compose` command fails.
3. Remove unnecessary dependencies.