### PR TITLE
Support port forwarding in Python CLI

### DIFF
--- a/python_cli/README.md
+++ b/python_cli/README.md
@@ -66,7 +66,7 @@ liquidai model run-model-image \
   --name lfm-3b-e \
   --image "liquidai/lfm-3b-e:0.0.6"
 
-# Run a HuggingFace model
+# Run a HuggingFace model and expose on port 9000
 liquidai model run-hf \
   --name llama-7b \
   --path meta-llama/Llama-2-7b-chat-hf \
@@ -75,10 +75,10 @@ liquidai model run-hf \
   --max-num-seqs 600 \
   --max-model-len 32768
 
-# Run a local checkpoint
+# Run a local checkpoint and expose on port 9001 to avoid conflicts
 liquidai model run-checkpoint \
   --path /path/to/checkpoint \
-  --port 9000 \
+  --port 9001 \
   --gpu-memory-utilization 0.6 \
   --max-num-seqs 600
 


### PR DESCRIPTION
Before this PR, `--port` variable on running model commands will only change the port within Docker container. This PR will force vLLM to be launched on port 9000 and forward them to the port assigned by users. By default, we don't expose this port because users are able to access the model through the labs Python API stack.